### PR TITLE
Bug Fix - useEvent not working as expected

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -18,29 +18,22 @@ export { useSubscription };
 
 export type EventHookParams<T> = {
     initialValue?: T;
-    reducer?: (value?: T) => void;
-    receiveLastValue: false;
-}
+    reducer?: (value?: T) => any;
+};
 
 /**
  * React Hook to subscribe to an Event.
  * @param {Event} event - The event.
- * @param {any} initialValue -  An Initial Value for the state.
- * @param {Function} reducer - A function to transform the state before return the value.
+ * @param {EventHookParams} params -  An Initial Value for the state.
  */
 function useEvent<T>(event: Event<T>, params?: EventHookParams<T>) {
-    const [value, setValue] = useState(params?.receiveLastValue ? event.get() : params?.initialValue);
+    const [value, setValue] = useState(event.get() ?? params?.initialValue);
 
-    useEffect(() => {
-        const handleStateChange = (state?: any) => {
-            if (params?.reducer)
-                state = params.reducer(state);
-            setValue(state)
-        };
-        const subscription = event.subscribe(handleStateChange);
-        return () => {
-            subscription.unsubscribe();
-        };
+    useSubscription(event, (_value) => {
+        if (params?.reducer) {
+        _value = params.reducer(_value);
+        }
+        setValue(_value);
     });
 
     return value;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -31,11 +31,16 @@ export type EventHookParams<T> = {
 function useEvent<T>(event: Event<T>, params?: EventHookParams<T>) {
     const [value, setValue] = useState(event.get() ?? params?.initialValue);
 
-    useSubscription(event, (_value) => {
-        if (params?.reducer) {
-            _value = params.reducer(_value);
-        }
-        setValue(_value);
+    useEffect(() => {
+        const handleStateChange = (state?: any) => {
+            if (params?.reducer)
+                state = params.reducer(state);
+            setValue(state)
+        };
+        const subscription = event.subscribe(handleStateChange);
+        return () => {
+            subscription.unsubscribe();
+        };
     });
 
     return value;


### PR DESCRIPTION
The `useEvent` hook was not working as expected as the initial value condition was not being properly handled.
also, the `useEffect` hook could be replaced by the `useSubscription` hook to improve reusability.