### PR TITLE
Feature/improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     'eslint:recommended',
     'eslint-config-prettier',
     'plugin:jsdoc/recommended',
+    'plugin:react-hooks/recommended',
   ],
   ignorePatterns: ['lib/**/*.js.', 'lib/*.js'],
   env: {

--- a/docs/classes/_event_.event.md
+++ b/docs/classes/_event_.event.md
@@ -37,7 +37,7 @@ New Event Classes
 
 \+ **new Event**(`eventDescriptor?`: [EventParams](../modules/_event_.md#eventparams)‹T›): *[Event](_event_.event.md)*
 
-*Defined in [src/event.ts:16](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L16)*
+*Defined in [src/event.ts:16](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L16)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ Name | Type |
 
 • **publisher**: *[Publisher](../interfaces/_pub_sub_.publisher.md)‹T›* = new ConcretePublisher()
 
-*Defined in [src/event.ts:16](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L16)*
+*Defined in [src/event.ts:16](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L16)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **reducer**? : *[Reducer](../modules/_event_.md#reducer)‹T›*
 
-*Defined in [src/event.ts:15](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L15)*
+*Defined in [src/event.ts:15](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L15)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **value**: *T | null* = null
 
-*Defined in [src/event.ts:14](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L14)*
+*Defined in [src/event.ts:14](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L14)*
 
 ## Methods
 
@@ -77,7 +77,7 @@ ___
 
 ▸ **clear**(`dispatch`: boolean): *void*
 
-*Defined in [src/event.ts:48](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L48)*
+*Defined in [src/event.ts:48](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L48)*
 
 Removes all data from the Event store
 
@@ -95,7 +95,7 @@ ___
 
 ▸ **dispatch**(`value`: T | null): *void*
 
-*Defined in [src/event.ts:33](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L33)*
+*Defined in [src/event.ts:33](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L33)*
 
 **Parameters:**
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **get**(): *T | null*
 
-*Defined in [src/event.ts:41](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L41)*
+*Defined in [src/event.ts:41](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L41)*
 
 **Returns:** *T | null*
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **subscribe**(`subscriber`: function, `receiveLastValue`: boolean): *[Subscription](../interfaces/_pub_sub_.subscription.md)*
 
-*Defined in [src/event.ts:24](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L24)*
+*Defined in [src/event.ts:24](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L24)*
 
 **Parameters:**
 

--- a/docs/classes/_event_.event.md
+++ b/docs/classes/_event_.event.md
@@ -37,7 +37,7 @@ New Event Classes
 
 \+ **new Event**(`eventDescriptor?`: [EventParams](../modules/_event_.md#eventparams)‹T›): *[Event](_event_.event.md)*
 
-*Defined in [src/event.ts:16](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L16)*
+*Defined in [src/event.ts:16](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L16)*
 
 **Parameters:**
 
@@ -53,7 +53,7 @@ Name | Type |
 
 • **publisher**: *[Publisher](../interfaces/_pub_sub_.publisher.md)‹T›* = new ConcretePublisher()
 
-*Defined in [src/event.ts:16](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L16)*
+*Defined in [src/event.ts:16](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L16)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **reducer**? : *[Reducer](../modules/_event_.md#reducer)‹T›*
 
-*Defined in [src/event.ts:15](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L15)*
+*Defined in [src/event.ts:15](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L15)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **value**: *T | null* = null
 
-*Defined in [src/event.ts:14](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L14)*
+*Defined in [src/event.ts:14](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L14)*
 
 ## Methods
 
@@ -77,7 +77,7 @@ ___
 
 ▸ **clear**(`dispatch`: boolean): *void*
 
-*Defined in [src/event.ts:48](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L48)*
+*Defined in [src/event.ts:48](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L48)*
 
 Removes all data from the Event store
 
@@ -95,7 +95,7 @@ ___
 
 ▸ **dispatch**(`value`: T | null): *void*
 
-*Defined in [src/event.ts:33](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L33)*
+*Defined in [src/event.ts:33](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L33)*
 
 **Parameters:**
 
@@ -111,7 +111,7 @@ ___
 
 ▸ **get**(): *T | null*
 
-*Defined in [src/event.ts:41](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L41)*
+*Defined in [src/event.ts:41](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L41)*
 
 **Returns:** *T | null*
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **subscribe**(`subscriber`: function, `receiveLastValue`: boolean): *[Subscription](../interfaces/_pub_sub_.subscription.md)*
 
-*Defined in [src/event.ts:24](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L24)*
+*Defined in [src/event.ts:24](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L24)*
 
 **Parameters:**
 

--- a/docs/classes/_pub_sub_.concretepublisher.md
+++ b/docs/classes/_pub_sub_.concretepublisher.md
@@ -35,7 +35,7 @@ A simple publisher
 
 *Implementation of [Publisher](../interfaces/_pub_sub_.publisher.md).[subscribers](../interfaces/_pub_sub_.publisher.md#subscribers)*
 
-*Defined in [src/pub-sub.ts:45](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L45)*
+*Defined in [src/pub-sub.ts:45](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L45)*
 
 ## Methods
 
@@ -45,7 +45,7 @@ A simple publisher
 
 *Implementation of [Publisher](../interfaces/_pub_sub_.publisher.md)*
 
-*Defined in [src/pub-sub.ts:56](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L56)*
+*Defined in [src/pub-sub.ts:56](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L56)*
 
 **Parameters:**
 
@@ -63,7 +63,7 @@ ___
 
 *Implementation of [Publisher](../interfaces/_pub_sub_.publisher.md)*
 
-*Defined in [src/pub-sub.ts:47](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L47)*
+*Defined in [src/pub-sub.ts:47](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L47)*
 
 **Parameters:**
 

--- a/docs/classes/_pub_sub_.concretepublisher.md
+++ b/docs/classes/_pub_sub_.concretepublisher.md
@@ -35,7 +35,7 @@ A simple publisher
 
 *Implementation of [Publisher](../interfaces/_pub_sub_.publisher.md).[subscribers](../interfaces/_pub_sub_.publisher.md#subscribers)*
 
-*Defined in [src/pub-sub.ts:45](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L45)*
+*Defined in [src/pub-sub.ts:45](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L45)*
 
 ## Methods
 
@@ -45,7 +45,7 @@ A simple publisher
 
 *Implementation of [Publisher](../interfaces/_pub_sub_.publisher.md)*
 
-*Defined in [src/pub-sub.ts:56](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L56)*
+*Defined in [src/pub-sub.ts:56](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L56)*
 
 **Parameters:**
 
@@ -63,7 +63,7 @@ ___
 
 *Implementation of [Publisher](../interfaces/_pub_sub_.publisher.md)*
 
-*Defined in [src/pub-sub.ts:47](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L47)*
+*Defined in [src/pub-sub.ts:47](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L47)*
 
 **Parameters:**
 

--- a/docs/classes/_pub_sub_.concretesubscription.md
+++ b/docs/classes/_pub_sub_.concretesubscription.md
@@ -37,7 +37,7 @@ An Object that represent the subscription to a Publisher
 
 \+ **new ConcreteSubscription**(`publisher`: [Publisher](../interfaces/_pub_sub_.publisher.md)‹T›, `subscriber`: [Subscriber](../interfaces/_pub_sub_.subscriber.md)‹T›): *[ConcreteSubscription](_pub_sub_.concretesubscription.md)*
 
-*Defined in [src/pub-sub.ts:22](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L22)*
+*Defined in [src/pub-sub.ts:22](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L22)*
 
 **Parameters:**
 
@@ -54,7 +54,7 @@ Name | Type |
 
 • **publisher**: *[Publisher](../interfaces/_pub_sub_.publisher.md)‹T› | null* = null
 
-*Defined in [src/pub-sub.ts:21](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L21)*
+*Defined in [src/pub-sub.ts:21](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L21)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • **subscriber**: *[Subscriber](../interfaces/_pub_sub_.subscriber.md)‹T› | null* = null
 
-*Defined in [src/pub-sub.ts:22](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L22)*
+*Defined in [src/pub-sub.ts:22](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L22)*
 
 ## Methods
 
@@ -72,6 +72,6 @@ ___
 
 *Implementation of [Subscription](../interfaces/_pub_sub_.subscription.md)*
 
-*Defined in [src/pub-sub.ts:29](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L29)*
+*Defined in [src/pub-sub.ts:29](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L29)*
 
 **Returns:** *void*

--- a/docs/classes/_pub_sub_.concretesubscription.md
+++ b/docs/classes/_pub_sub_.concretesubscription.md
@@ -37,7 +37,7 @@ An Object that represent the subscription to a Publisher
 
 \+ **new ConcreteSubscription**(`publisher`: [Publisher](../interfaces/_pub_sub_.publisher.md)‹T›, `subscriber`: [Subscriber](../interfaces/_pub_sub_.subscriber.md)‹T›): *[ConcreteSubscription](_pub_sub_.concretesubscription.md)*
 
-*Defined in [src/pub-sub.ts:22](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L22)*
+*Defined in [src/pub-sub.ts:22](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L22)*
 
 **Parameters:**
 
@@ -54,7 +54,7 @@ Name | Type |
 
 • **publisher**: *[Publisher](../interfaces/_pub_sub_.publisher.md)‹T› | null* = null
 
-*Defined in [src/pub-sub.ts:21](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L21)*
+*Defined in [src/pub-sub.ts:21](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L21)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • **subscriber**: *[Subscriber](../interfaces/_pub_sub_.subscriber.md)‹T› | null* = null
 
-*Defined in [src/pub-sub.ts:22](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L22)*
+*Defined in [src/pub-sub.ts:22](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L22)*
 
 ## Methods
 
@@ -72,6 +72,6 @@ ___
 
 *Implementation of [Subscription](../interfaces/_pub_sub_.subscription.md)*
 
-*Defined in [src/pub-sub.ts:29](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L29)*
+*Defined in [src/pub-sub.ts:29](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L29)*
 
 **Returns:** *void*

--- a/docs/classes/_views_.view.md
+++ b/docs/classes/_views_.view.md
@@ -129,7 +129,7 @@ ___
 
 • **hasBeenUnmounted**: *boolean* = false
 
-*Defined in [src/views.ts:9](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L9)*
+*Defined in [src/views.ts:9](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/views.ts#L9)*
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 • **subscriptions**: *[Subscription](../interfaces/_pub_sub_.subscription.md)[]* = []
 
-*Defined in [src/views.ts:7](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L7)*
+*Defined in [src/views.ts:7](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/views.ts#L7)*
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 • **toBeSubscribedIfUnMounted**: *[LocalObserver](../modules/_types_.md#localobserver)‹T›[]* = []
 
-*Defined in [src/views.ts:8](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L8)*
+*Defined in [src/views.ts:8](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/views.ts#L8)*
 
 ___
 
@@ -340,7 +340,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/views.ts:27](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L27)*
+*Defined in [src/views.ts:27](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/views.ts#L27)*
 
 **Returns:** *void*
 
@@ -434,7 +434,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/views.ts:47](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L47)*
+*Defined in [src/views.ts:47](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/views.ts#L47)*
 
 **Returns:** *void*
 
@@ -585,7 +585,7 @@ ___
 
 ▸ **subscribe**(`event`: [Event](_event_.event.md)‹T›, `callback`: function, `receiveLastValue`: boolean): *[Subscription](../interfaces/_pub_sub_.subscription.md)*
 
-*Defined in [src/views.ts:19](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L19)*
+*Defined in [src/views.ts:19](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/views.ts#L19)*
 
 Subscribe to an Event
 This is a helpful method to keep track of your subscriptions on UnMount and Mount of the Component

--- a/docs/classes/_views_.view.md
+++ b/docs/classes/_views_.view.md
@@ -129,7 +129,7 @@ ___
 
 • **hasBeenUnmounted**: *boolean* = false
 
-*Defined in [src/views.ts:9](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/views.ts#L9)*
+*Defined in [src/views.ts:9](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L9)*
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 • **subscriptions**: *[Subscription](../interfaces/_pub_sub_.subscription.md)[]* = []
 
-*Defined in [src/views.ts:7](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/views.ts#L7)*
+*Defined in [src/views.ts:7](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L7)*
 
 ___
 
@@ -182,7 +182,7 @@ ___
 
 • **toBeSubscribedIfUnMounted**: *[LocalObserver](../modules/_types_.md#localobserver)‹T›[]* = []
 
-*Defined in [src/views.ts:8](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/views.ts#L8)*
+*Defined in [src/views.ts:8](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L8)*
 
 ___
 
@@ -340,7 +340,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/views.ts:27](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/views.ts#L27)*
+*Defined in [src/views.ts:27](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L27)*
 
 **Returns:** *void*
 
@@ -434,7 +434,7 @@ ___
 
 *Overrides void*
 
-*Defined in [src/views.ts:47](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/views.ts#L47)*
+*Defined in [src/views.ts:47](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L47)*
 
 **Returns:** *void*
 
@@ -585,7 +585,7 @@ ___
 
 ▸ **subscribe**(`event`: [Event](_event_.event.md)‹T›, `callback`: function, `receiveLastValue`: boolean): *[Subscription](../interfaces/_pub_sub_.subscription.md)*
 
-*Defined in [src/views.ts:19](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/views.ts#L19)*
+*Defined in [src/views.ts:19](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/views.ts#L19)*
 
 Subscribe to an Event
 This is a helpful method to keep track of your subscriptions on UnMount and Mount of the Component

--- a/docs/interfaces/_pub_sub_.publisher.md
+++ b/docs/interfaces/_pub_sub_.publisher.md
@@ -31,7 +31,7 @@
 
 • **subscribers**: *[Subscriber](_pub_sub_.subscriber.md)‹T›[]*
 
-*Defined in [src/pub-sub.ts:10](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L10)*
+*Defined in [src/pub-sub.ts:10](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L10)*
 
 ## Methods
 
@@ -39,7 +39,7 @@
 
 ▸ **notify**(`value`: T | null): *void*
 
-*Defined in [src/pub-sub.ts:14](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L14)*
+*Defined in [src/pub-sub.ts:14](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L14)*
 
 **Parameters:**
 
@@ -55,7 +55,7 @@ ___
 
 ▸ **subscribe**(`subscriber`: [Subscriber](_pub_sub_.subscriber.md)‹T›): *[Subscription](_pub_sub_.subscription.md)*
 
-*Defined in [src/pub-sub.ts:12](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L12)*
+*Defined in [src/pub-sub.ts:12](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L12)*
 
 **Parameters:**
 

--- a/docs/interfaces/_pub_sub_.publisher.md
+++ b/docs/interfaces/_pub_sub_.publisher.md
@@ -31,7 +31,7 @@
 
 • **subscribers**: *[Subscriber](_pub_sub_.subscriber.md)‹T›[]*
 
-*Defined in [src/pub-sub.ts:10](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L10)*
+*Defined in [src/pub-sub.ts:10](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L10)*
 
 ## Methods
 
@@ -39,7 +39,7 @@
 
 ▸ **notify**(`value`: T | null): *void*
 
-*Defined in [src/pub-sub.ts:14](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L14)*
+*Defined in [src/pub-sub.ts:14](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L14)*
 
 **Parameters:**
 
@@ -55,7 +55,7 @@ ___
 
 ▸ **subscribe**(`subscriber`: [Subscriber](_pub_sub_.subscriber.md)‹T›): *[Subscription](_pub_sub_.subscription.md)*
 
-*Defined in [src/pub-sub.ts:12](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L12)*
+*Defined in [src/pub-sub.ts:12](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L12)*
 
 **Parameters:**
 

--- a/docs/interfaces/_pub_sub_.subscriber.md
+++ b/docs/interfaces/_pub_sub_.subscriber.md
@@ -22,7 +22,7 @@
 
 • **update**: *function*
 
-*Defined in [src/pub-sub.ts:6](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L6)*
+*Defined in [src/pub-sub.ts:6](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L6)*
 
 #### Type declaration:
 

--- a/docs/interfaces/_pub_sub_.subscriber.md
+++ b/docs/interfaces/_pub_sub_.subscriber.md
@@ -22,7 +22,7 @@
 
 • **update**: *function*
 
-*Defined in [src/pub-sub.ts:6](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L6)*
+*Defined in [src/pub-sub.ts:6](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L6)*
 
 #### Type declaration:
 

--- a/docs/interfaces/_pub_sub_.subscription.md
+++ b/docs/interfaces/_pub_sub_.subscription.md
@@ -22,6 +22,6 @@
 
 ▸ **unsubscribe**(): *void*
 
-*Defined in [src/pub-sub.ts:2](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/pub-sub.ts#L2)*
+*Defined in [src/pub-sub.ts:2](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L2)*
 
 **Returns:** *void*

--- a/docs/interfaces/_pub_sub_.subscription.md
+++ b/docs/interfaces/_pub_sub_.subscription.md
@@ -22,6 +22,6 @@
 
 ▸ **unsubscribe**(): *void*
 
-*Defined in [src/pub-sub.ts:2](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/pub-sub.ts#L2)*
+*Defined in [src/pub-sub.ts:2](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/pub-sub.ts#L2)*
 
 **Returns:** *void*

--- a/docs/modules/_event_.md
+++ b/docs/modules/_event_.md
@@ -23,7 +23,7 @@
 
 Ƭ **EventParams**: *object*
 
-*Defined in [src/event.ts:5](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L5)*
+*Defined in [src/event.ts:5](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L5)*
 
 #### Type declaration:
 
@@ -37,7 +37,7 @@ ___
 
 Ƭ **Reducer**: *function*
 
-*Defined in [src/event.ts:3](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L3)*
+*Defined in [src/event.ts:3](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L3)*
 
 #### Type declaration:
 
@@ -55,7 +55,7 @@ Name | Type |
 
 ▸ **createEvent**‹**T**›(`eventDescriptor?`: [EventParams](_event_.md#eventparams)‹T›): *[Event](../classes/_event_.event.md)‹T›*
 
-*Defined in [src/event.ts:62](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/event.ts#L62)*
+*Defined in [src/event.ts:62](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L62)*
 
 Creates an event from a descriptor.
 

--- a/docs/modules/_event_.md
+++ b/docs/modules/_event_.md
@@ -23,7 +23,7 @@
 
 Ƭ **EventParams**: *object*
 
-*Defined in [src/event.ts:5](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L5)*
+*Defined in [src/event.ts:5](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L5)*
 
 #### Type declaration:
 
@@ -37,7 +37,7 @@ ___
 
 Ƭ **Reducer**: *function*
 
-*Defined in [src/event.ts:3](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L3)*
+*Defined in [src/event.ts:3](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L3)*
 
 #### Type declaration:
 
@@ -55,7 +55,7 @@ Name | Type |
 
 ▸ **createEvent**‹**T**›(`eventDescriptor?`: [EventParams](_event_.md#eventparams)‹T›): *[Event](../classes/_event_.event.md)‹T›*
 
-*Defined in [src/event.ts:62](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/event.ts#L62)*
+*Defined in [src/event.ts:62](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/event.ts#L62)*
 
 Creates an event from a descriptor.
 

--- a/docs/modules/_hooks_.md
+++ b/docs/modules/_hooks_.md
@@ -19,7 +19,7 @@
 
 Ƭ **EventHookParams**: *object*
 
-*Defined in [src/hooks.ts:23](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/hooks.ts#L23)*
+*Defined in [src/hooks.ts:28](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/hooks.ts#L28)*
 
 #### Type declaration:
 
@@ -33,7 +33,7 @@
 
 ▸ **useEvent**‹**T**›(`event`: [Event](../classes/_event_.event.md)‹T›, `params?`: [EventHookParams](_hooks_.md#eventhookparams)‹T›): *null | T*
 
-*Defined in [src/hooks.ts:34](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/hooks.ts#L34)*
+*Defined in [src/hooks.ts:42](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/hooks.ts#L42)*
 
 React Hook to subscribe to an Event.
 
@@ -46,23 +46,27 @@ React Hook to subscribe to an Event.
 Name | Type | Description |
 ------ | ------ | ------ |
 `event` | [Event](../classes/_event_.event.md)‹T› | The event. |
-`params?` | [EventHookParams](_hooks_.md#eventhookparams)‹T› | - |
+`params?` | [EventHookParams](_hooks_.md#eventhookparams)‹T› | Params. |
 
 **Returns:** *null | T*
+
+Data object.
 
 ___
 
 ###  useSubscription
 
-▸ **useSubscription**‹**T**›(`event`: [Event](../classes/_event_.event.md)‹T›, `callback`: function, `deps`: any[]): *void*
+▸ **useSubscription**‹**T**, **U**›(`event`: [Event](../classes/_event_.event.md)‹T›, `callback`: function, `deps`: U[]): *void*
 
-*Defined in [src/hooks.ts:10](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/hooks.ts#L10)*
+*Defined in [src/hooks.ts:11](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/hooks.ts#L11)*
 
-React Hook to subscribe to an specific event
+React Hook to subscribe to an specific event.
 
 **Type parameters:**
 
 ▪ **T**
+
+▪ **U**
 
 **Parameters:**
 
@@ -74,15 +78,15 @@ The event to subscribe. The Event is considered constant across renders.
 
 A function to be called when the subscription gets triggered.
 
-▸ (`value?`: T): *void*
+▸ (`value`: T | null): *void*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`value?` | T |
+`value` | T &#124; null |
 
-▪ **deps**: *any[]*
+▪ **deps**: *U[]*
 
 List of dependencies for the callback. Follow the same rules of useEffect.
 

--- a/docs/modules/_hooks_.md
+++ b/docs/modules/_hooks_.md
@@ -19,7 +19,7 @@
 
 Ƭ **EventHookParams**: *object*
 
-*Defined in [src/hooks.ts:28](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/hooks.ts#L28)*
+*Defined in [src/hooks.ts:28](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/hooks.ts#L28)*
 
 #### Type declaration:
 
@@ -33,7 +33,7 @@
 
 ▸ **useEvent**‹**T**›(`event`: [Event](../classes/_event_.event.md)‹T›, `params?`: [EventHookParams](_hooks_.md#eventhookparams)‹T›): *null | T*
 
-*Defined in [src/hooks.ts:42](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/hooks.ts#L42)*
+*Defined in [src/hooks.ts:42](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/hooks.ts#L42)*
 
 React Hook to subscribe to an Event.
 
@@ -58,7 +58,7 @@ ___
 
 ▸ **useSubscription**‹**T**, **U**›(`event`: [Event](../classes/_event_.event.md)‹T›, `callback`: function, `deps`: U[]): *void*
 
-*Defined in [src/hooks.ts:11](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/hooks.ts#L11)*
+*Defined in [src/hooks.ts:11](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/hooks.ts#L11)*
 
 React Hook to subscribe to an specific event.
 

--- a/docs/modules/_types_.md
+++ b/docs/modules/_types_.md
@@ -15,7 +15,7 @@
 
 Ƭ **LocalObserver**: *object*
 
-*Defined in [src/types.ts:7](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/types.ts#L7)*
+*Defined in [src/types.ts:7](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/types.ts#L7)*
 
 #### Type declaration:
 
@@ -37,7 +37,7 @@ ___
 
 Ƭ **Store**: *object*
 
-*Defined in [src/types.ts:3](https://github.com/cobuildlab/react-simple-state/blob/269d4ef/src/types.ts#L3)*
+*Defined in [src/types.ts:3](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/types.ts#L3)*
 
 #### Type declaration:
 

--- a/docs/modules/_types_.md
+++ b/docs/modules/_types_.md
@@ -15,7 +15,7 @@
 
 Ƭ **LocalObserver**: *object*
 
-*Defined in [src/types.ts:7](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/types.ts#L7)*
+*Defined in [src/types.ts:7](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/types.ts#L7)*
 
 #### Type declaration:
 
@@ -37,7 +37,7 @@ ___
 
 Ƭ **Store**: *object*
 
-*Defined in [src/types.ts:3](https://github.com/cobuildlab/react-simple-state/blob/54fb38a/src/types.ts#L3)*
+*Defined in [src/types.ts:3](https://github.com/cobuildlab/react-simple-state/blob/8e6ada3/src/types.ts#L3)*
 
 #### Type declaration:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3570,6 +3570,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.6.tgz",
+      "integrity": "sha512-RDrsUR/BjwCECcWS+5bc7mWiU/M1IOizKt40Zuei5mn0Eydubiooh87aSCiZ/BGMSUF7P8AqyMEqQL0RsAihmw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-jest": "^23.13.1",
     "eslint-plugin-jsdoc": "^25.4.1",
+    "eslint-plugin-react-hooks": "^4.0.6",
     "husky": "^4.2.5",
     "jest": "^26.0.1",
     "lint-staged": "^10.2.2",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -20,7 +20,7 @@ function useSubscription<T, U>(
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [event, deps]);
+  }, [event, ...deps]);
 }
 
 export { useSubscription };


### PR DESCRIPTION
- Remove the use callback inside the useSubscription hooks, and move the deps array directly to the useEffect hook so we have the same behavior without the extra logic of the useCallback
- Remove the deps arrays declarationinside the useEvent hook due the creation of the reference on every render so it's a performance leak