### PR TITLE
Fix issue in events initial value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobuildlab/react-simple-state",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Simple and Lightweight state management for react applications. ",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/__tests__/event-test.ts
+++ b/src/__tests__/event-test.ts
@@ -9,6 +9,9 @@ test("createEvent:", () => {
     const eventWithInitial = createEvent({initialValue: 1});
     expect(eventWithInitial.get()).toBe(1);
 
+    const eventWithInitialFalsy = createEvent({initialValue: 0});
+    expect(eventWithInitialFalsy.get()).toBe(0);
+
     const eventWithReducer = createEvent({reducer: (val: any) => !val});
     eventWithReducer.subscribe(val => {
         expect(val).toBe(false);

--- a/src/event.ts
+++ b/src/event.ts
@@ -23,8 +23,7 @@ export class Event<T, U = unknown> {
   private isEventEmpty = true;
 
   constructor(eventDescriptor?: EventParams<T, U>) {
-    if (eventDescriptor && eventDescriptor.initialValue)
-      this.value = eventDescriptor.initialValue;
+    this.value = eventDescriptor?.initialValue ?? null;
     this.reducer = eventDescriptor?.reducer;
   }
 


### PR DESCRIPTION
# Proposal

Fix the initialisation of event, so that it's initial value is set even if the value resolves as falsy.


## Details

This is required so that the initial value of an event can be set to a falsy value e.g. false, 0 or '', with the obvious exception of null or undefined.

If the initial value is either undefined or null, the value will resolve to null.  This is consistent with the events current typing.